### PR TITLE
Initial ARD WG Concourse configuration

### DIFF
--- a/terragrunt/concourse-wg-ci/app/.terraform.lock.hcl
+++ b/terragrunt/concourse-wg-ci/app/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "4.42.0"
   hashes = [
+    "h1:2DebPkZAqZE5DpKNN0MJA9E4WRyARbxSzOUlstdYlW4=",
     "h1:hYwc7stdvS8gbKIYcxtpVnRAHpxf2YycrOPOfeJWjvk=",
     "h1:sEbuoQzQEIzqric0xit5Lm5FrEF5+plvyWuP/xKOyDA=",
     "zh:42372be4b901b3c9cecc5331d99b007338d152b9cacfe742a6a722b3c32b1fc0",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version = "2.7.1"
   hashes = [
     "h1:11oWNeohjD8Fy9S7WQSKY3GmDZi7gVdMRp8/Wqxn410=",
+    "h1:L5qLTfZH7PnZt9+YnS7iYmPBEDQOpEjZiF0v50BRNi8=",
     "h1:OGZRkgiLBWmoA8/a9xZnEs5gsC5JhW+75++MkCPQbqw=",
     "zh:13e2467092deeff01c4cfa2b54ba4510aa7a9b06c58f22c4215b0f4333858364",
     "zh:4549843db4fdf5d8150e8c0734e67b54b5c3bcfc914e3221e6952f428fb984d2",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.15.0"
   hashes = [
     "h1:Gcy0a0uHLgHJdqs9le6S0f8zp3xpmHKxH48el5kT0iI=",
+    "h1:tnz+6mdJYhK6OZRmQMZJz3+cDHXNLK69q2Zwt1BG3tw=",
     "h1:wAdoEHV4gXntbTcKkva3AKQKt1+BZL9Bi+Z+RZjFYyc=",
     "zh:108011c33c0fc0b4d429d511bf97744b40b1ab261d51d413b3bffc8247369f26",
     "zh:3ac39669fa20b7e0430753c3023d8393348213a84c69a18dc75057761478cfcf",
@@ -64,19 +67,6 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 provider "registry.terraform.io/vmware-tanzu/carvel" {
   version = "0.11.0"
   hashes = [
-    "h1:HslYwK+G5J3IdsXMx0ZMU2p6g1Ef7aVfUtZZu4YYJsg=",
-    "h1:eZ1vBbOHZXncW/VMApPy48ILXqZq71BXpq8KhcN5HI4=",
-    "zh:3c30070314cd7da84da2d5a92727fb73b1df9d7b84741f6f546a371ee8888343",
-    "zh:47a956718197e8acc997a80723b341564c65650e7157ac3bc37fe87193421e26",
-    "zh:4c50d7039bb5ed10343428809ffb76eb2614a136009d346dcbc33fadc41f6e62",
-    "zh:5e51a8c5f6ce40e504245f650471aebcbe496eddb6e45d6fa39464cae1826fed",
-    "zh:6b0bbf211d430b82ccc0b48bb968a6774cb2cdf14857082f08b17cfba0001840",
-    "zh:6e2ff5f40826cac5c67426dbb1cbb7d87db8d159c086942e261d9408a3dd727b",
-    "zh:87e5131ffc9e49aa4f0870fce306741869d3db16182fce447a54f5c983ecd427",
-    "zh:aa62d835e25423fb006fac9abfe831df1f54abef1ac85cf03f8c0e334f437fc5",
-    "zh:b2d4ef885ecc97b2e577e5ee99d9c51237aaa903a6cdf54fc16dc24922521a2d",
-    "zh:c90a853e5eb6873fc3470016f2b91a73ea564a6b2c05b5869527b9fd7a8ae799",
-    "zh:cbd57379966e609d9a600dc89783b41ac64601c13b87ca3a5b0b5be254181e2d",
-    "zh:e6e538fe5ebd296a7a2325095bfad34148fe043e5219ea6f067f25f915bf881d",
+    "h1:STVDjE6YLwENYm8+mEY18hlrofEMc8yQvXj2lTeXTU4=",
   ]
 }

--- a/terragrunt/concourse-wg-ci/backend/.terraform.lock.hcl
+++ b/terragrunt/concourse-wg-ci/backend/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/gavinbunney/kubectl" {
   version = "1.14.0"
   hashes = [
+    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
     "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
     "h1:mX2AOFIMIxJmW5kM8DT51gloIOKCr9iT6W8yodnUyfs=",
     "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
@@ -43,6 +44,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.15.0"
   hashes = [
     "h1:Gcy0a0uHLgHJdqs9le6S0f8zp3xpmHKxH48el5kT0iI=",
+    "h1:tnz+6mdJYhK6OZRmQMZJz3+cDHXNLK69q2Zwt1BG3tw=",
     "h1:wAdoEHV4gXntbTcKkva3AKQKt1+BZL9Bi+Z+RZjFYyc=",
     "zh:108011c33c0fc0b4d429d511bf97744b40b1ab261d51d413b3bffc8247369f26",
     "zh:3ac39669fa20b7e0430753c3023d8393348213a84c69a18dc75057761478cfcf",
@@ -62,19 +64,6 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 provider "registry.terraform.io/vmware-tanzu/carvel" {
   version = "0.11.0"
   hashes = [
-    "h1:HslYwK+G5J3IdsXMx0ZMU2p6g1Ef7aVfUtZZu4YYJsg=",
-    "h1:eZ1vBbOHZXncW/VMApPy48ILXqZq71BXpq8KhcN5HI4=",
-    "zh:3c30070314cd7da84da2d5a92727fb73b1df9d7b84741f6f546a371ee8888343",
-    "zh:47a956718197e8acc997a80723b341564c65650e7157ac3bc37fe87193421e26",
-    "zh:4c50d7039bb5ed10343428809ffb76eb2614a136009d346dcbc33fadc41f6e62",
-    "zh:5e51a8c5f6ce40e504245f650471aebcbe496eddb6e45d6fa39464cae1826fed",
-    "zh:6b0bbf211d430b82ccc0b48bb968a6774cb2cdf14857082f08b17cfba0001840",
-    "zh:6e2ff5f40826cac5c67426dbb1cbb7d87db8d159c086942e261d9408a3dd727b",
-    "zh:87e5131ffc9e49aa4f0870fce306741869d3db16182fce447a54f5c983ecd427",
-    "zh:aa62d835e25423fb006fac9abfe831df1f54abef1ac85cf03f8c0e334f437fc5",
-    "zh:b2d4ef885ecc97b2e577e5ee99d9c51237aaa903a6cdf54fc16dc24922521a2d",
-    "zh:c90a853e5eb6873fc3470016f2b91a73ea564a6b2c05b5869527b9fd7a8ae799",
-    "zh:cbd57379966e609d9a600dc89783b41ac64601c13b87ca3a5b0b5be254181e2d",
-    "zh:e6e538fe5ebd296a7a2325095bfad34148fe043e5219ea6f067f25f915bf881d",
+    "h1:STVDjE6YLwENYm8+mEY18hlrofEMc8yQvXj2lTeXTU4=",
   ]
 }

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -4,12 +4,12 @@ zone: europe-west3-a
 secondary_zone: europe-west3-b
 
 # gcs_prefix builds root folder for tf state for the entire stack
-gcs_bucket: terraform-wg-ci
+gcs_bucket: terraform-ard-wg-ci
 gcs_prefix: concourse
 
 # DNS record for your Concourse URL https://<dns_record>.<dns_zone>.dns_domain
 dns_record: concourse
-dns_zone: app-runtime-deployments
+dns_zone: wg-ard
 dns_domain: ci.cloudfoundry.org
 
 # Project's resource names are build off GKE name for scaling purposes
@@ -45,7 +45,8 @@ sql_instance_backup_location: eu
 sql_instance_disk_size: 38
 
 # Other GKE vars
-gke_controlplane_version: 1.23.8-gke.1900
+# gke versions: see https://cloud.google.com/kubernetes-engine/docs/release-notes
+gke_controlplane_version: 1.24.8-gke.2000
 gke_cluster_ipv4_cidr: 10.104.0.0/14
 gke_services_ipv4_cidr_block: 10.108.0.0/20
 gke_master_ipv4_cidr_block: 172.16.0.32/28

--- a/terragrunt/concourse-wg-ci/config.yaml
+++ b/terragrunt/concourse-wg-ci/config.yaml
@@ -59,8 +59,8 @@ gke_default_pool_ssd_count: 0
 # typical config for concourse worker is n4-standard-4 and ssd_count: 1
 # note: economy e2-standard machine can't use local ssd drives
 gke_workers_pool_machine_type: e2-standard-4
-gke_workers_pool_node_count: 2
-gke_workers_pool_autoscaling_max: 4
+gke_workers_pool_node_count: 4
+gke_workers_pool_autoscaling_max: 6
 gke_workers_pool_ssd_count: 0
 
 # low number of preallocated ports will impact networking for heavy concourse pipelines

--- a/terragrunt/concourse-wg-ci/dr_create/.terraform.lock.hcl
+++ b/terragrunt/concourse-wg-ci/dr_create/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "4.43.0"
   hashes = [
+    "h1:JpShTtgnxpiIVnr0R2Lccrh84mnrf7Z1/v/yw0UZ1gI=",
     "h1:PSIkDVwksHe9oZd+XP369N8U+6/+SPF8Z5wHkcwmWKw=",
     "h1:gmUUWhuuY/YRIllvVBRGl1kUHqsNBHQ/4BHdwKQbzXQ=",
     "zh:0b424cab24856dc47177733145fa61b731f345a6a42a0c0b7910ccfcf4e8c8a2",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version = "4.43.0"
   hashes = [
     "h1:8VHj+IfnuSb4lB5j9Re3RLyTccwnqFZev1LPn8/5xCs=",
+    "h1:dgSzxlVzikZJlQFOgPZX4AL9fGZwVYjzLktcEkPTUyE=",
     "h1:hz/LB+GuYU3LkOEU6TSFBpaKU+MDP+HWhDY1X9k4wao=",
     "zh:1904afd736547da2563d51b3bbcb827ed6c488b30bcb60d19efd81153db10648",
     "zh:40d47748efb8d57096747834c5b6743f31012ae1d2ef3bb783505406e532f552",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version = "2.15.0"
   hashes = [
     "h1:Gcy0a0uHLgHJdqs9le6S0f8zp3xpmHKxH48el5kT0iI=",
+    "h1:tnz+6mdJYhK6OZRmQMZJz3+cDHXNLK69q2Zwt1BG3tw=",
     "h1:wAdoEHV4gXntbTcKkva3AKQKt1+BZL9Bi+Z+RZjFYyc=",
     "zh:108011c33c0fc0b4d429d511bf97744b40b1ab261d51d413b3bffc8247369f26",
     "zh:3ac39669fa20b7e0430753c3023d8393348213a84c69a18dc75057761478cfcf",


### PR DESCRIPTION
* note that "registry.terraform.io/vmware-tanzu/carvel" hashes refer to a locally ARM compiled version